### PR TITLE
Add 502 Bad Gateway Error

### DIFF
--- a/src/common/classes/common.classes.errors.ts
+++ b/src/common/classes/common.classes.errors.ts
@@ -135,6 +135,17 @@ class InternalServerError extends CustomError {
   }
 }
 
+class BadGatewayError extends CustomError {
+  constructor(message: string | null, originalError?: Error) {
+    super(
+      message || "Bad Gateway.",
+      StatusCodes.BAD_GATEWAY,
+      ErrorName.badGateway,
+      originalError,
+    );
+  }
+}
+
 type AppCustomErrorConstructor =
   | typeof ValidationError
   | typeof NotFoundError
@@ -145,6 +156,7 @@ type AppCustomErrorConstructor =
   | typeof ForbiddenError
   | typeof ConflictError
   | typeof BadRequestError
+  | typeof BadGatewayError
   | typeof InternalServerError;
 
 export type { AppCustomErrorConstructor };
@@ -161,4 +173,5 @@ export {
   ConflictError,
   BadRequestError,
   InternalServerError,
+  BadGatewayError,
 };

--- a/src/common/enums/common.enums.error-names.ts
+++ b/src/common/enums/common.enums.error-names.ts
@@ -9,6 +9,7 @@ const enum ErrorName {
   internalServerError = "internalservererror",
   forbidden = "forbiddenerror",
   conflict = "conflicterror",
+  badGateway = "badgatewayerror",
 }
 
 export { ErrorName };

--- a/src/common/helpers/helpers.get-error-constructor.ts
+++ b/src/common/helpers/helpers.get-error-constructor.ts
@@ -11,6 +11,7 @@ import {
   ConflictError,
   type AppCustomErrorConstructor,
   BadRequestError,
+  BadGatewayError,
 } from "../classes/common.classes.errors";
 import { assertUnreachable } from "../utils/common.utils.assert-unreachable";
 
@@ -54,6 +55,10 @@ function getErrorConstructor(errorName: ErrorName): AppCustomErrorConstructor {
 
     case ErrorName.internalServerError: {
       return InternalServerError;
+    }
+
+    case ErrorName.badGateway: {
+      return BadGatewayError;
     }
 
     default: {


### PR DESCRIPTION
## Feature: Add 502 Bad Gateway Error Handling

This PR extends the `amparo` library to support explicit handling of "502 Bad Gateway" errors within the `safe()` function. Previously, there was no built-in `ErrorName` or `CustomError` subclass for this specific HTTP status code, limiting the granularity of error categorization.

**Changes Made:**

To achieve this, the following modifications were implemented:

1.  **`src/common/enums/common.enums.error-names.ts`**:
    *   Added a new `ErrorName` enum member: `badGateway = "badgatewayerror"`. This provides a distinct identifier for 502 errors.

2.  **`src/common/classes/common.classes.errors.ts`**:
    *   Created a new `BadGatewayError` class that extends `CustomError`. This class is specifically configured with `StatusCodes.BAD_GATEWAY` and `ErrorName.badGateway`.
    *   Updated the `AppCustomErrorConstructor` type export to include `BadGatewayError`, ensuring it's recognized by the error handling system.

3.  **`src/common/helpers/helpers.get-error-constructor.ts`**:
    *   Modified the `getErrorConstructor` function to return the new `BadGatewayError` constructor when `ErrorName.badGateway` is provided as an argument.

**Why these changes?**

These changes enable developers using `amparo` to:

*   **Categorize 502 errors explicitly**: By having a dedicated `ErrorName` and `CustomError` type, 502 Bad Gateway errors can be clearly identified and handled.
*   **Improve error messaging**: The `safe()` function can now be used with a specific `ErrorName.badGateway` to provide more accurate and context-rich error messages for upstream service issues.
*   **Enhance error handling logic**: Allows for more precise conditional logic based on the type of error returned by `safe()`.

**Usage Example:**

After these changes, you can now use `safe()` to handle 502 Bad Gateway errors like this:

```typescript
import { safe, ErrorName } from 'amparo';

const result = await safe(
  callExternalService(),
  'The upstream service is currently unavailable.',
  ErrorName.badGateway,
);
}
```
