### PR TITLE
fix: support NodeNext module resolution and verbatimModuleSyntax

### DIFF
--- a/src/common/base/builders/common.base.builders.controller.ts
+++ b/src/common/base/builders/common.base.builders.controller.ts
@@ -1,5 +1,5 @@
 import { FastifyRequest, FastifyReply, RouteHandlerMethod } from "fastify";
-import { type BaseAppRequest } from "../types/common.base.types.requests";
+import { type BaseAppRequest } from "../types/common.base.types.requests.js";
 
 // Controller Types
 type BaseControllerHelper<

--- a/src/common/classes/common.classes.errors.ts
+++ b/src/common/classes/common.classes.errors.ts
@@ -1,5 +1,5 @@
 import { StatusCodes } from "http-status-codes";
-import { ErrorName } from "../enums/common.enums.error-names";
+import { ErrorName } from "../enums/common.enums.error-names.js";
 
 abstract class CustomError extends Error {
   status: StatusCodes;
@@ -94,7 +94,7 @@ class ForbiddenError extends CustomError {
   constructor(message: string | null, originalError?: Error) {
     super(
       message ||
-        "You don't have the neccesary permissions to perfom this action.",
+      "You don't have the neccesary permissions to perfom this action.",
       StatusCodes.FORBIDDEN,
       ErrorName.forbidden,
       originalError,

--- a/src/common/enums/common.enums.error-names.ts
+++ b/src/common/enums/common.enums.error-names.ts
@@ -1,4 +1,4 @@
-const enum ErrorName {
+declare enum ErrorName {
   badRequest = "badrequesterror",
   validation = "validationerror",
   notFound = "notfounderror",

--- a/src/common/helpers/helpers.get-error-constructor.ts
+++ b/src/common/helpers/helpers.get-error-constructor.ts
@@ -1,4 +1,4 @@
-import { ErrorName } from "../enums/common.enums.error-names";
+import { ErrorName } from "../enums/common.enums.error-names.js";
 import {
   ValidationError,
   NotFoundError,
@@ -11,8 +11,8 @@ import {
   ConflictError,
   type AppCustomErrorConstructor,
   BadRequestError,
-} from "../classes/common.classes.errors";
-import { assertUnreachable } from "../utils/common.utils.assert-unreachable";
+} from "../classes/common.classes.errors.js";
+import { assertUnreachable } from "../utils/common.utils.assert-unreachable.js";
 
 function getErrorConstructor(errorName: ErrorName): AppCustomErrorConstructor {
   switch (errorName) {

--- a/src/core/core.assert-with-typeguard.ts
+++ b/src/core/core.assert-with-typeguard.ts
@@ -1,5 +1,5 @@
-import { ErrorName } from "../common/enums/common.enums.error-names";
-import getErrorConstructor from "../common/helpers/helpers.get-error-constructor";
+import { ErrorName } from "../common/enums/common.enums.error-names.js";
+import getErrorConstructor from "../common/helpers/helpers.get-error-constructor.js";
 
 function assertWithTypeguard<T, V>(
   value: V,

--- a/src/core/core.assert.ts
+++ b/src/core/core.assert.ts
@@ -1,5 +1,5 @@
-import { ErrorName } from "../common";
-import getErrorConstructor from "../common/helpers/helpers.get-error-constructor";
+import { ErrorName } from "../common/index.js";
+import getErrorConstructor from "../common/helpers/helpers.get-error-constructor.js";
 
 function assert<T>(value: T, errorMessage: string, errorName: ErrorName) {
   if (value === null || value === undefined || value === false) {

--- a/src/core/core.safe.ts
+++ b/src/core/core.safe.ts
@@ -1,5 +1,5 @@
-import { ErrorName } from "../common";
-import getErrorConstructor from "../common/helpers/helpers.get-error-constructor";
+import { ErrorName } from "../common/index.js";
+import getErrorConstructor from "../common/helpers/helpers.get-error-constructor.js";
 
 /**
  * Function overloads for `safe`.

--- a/src/fastify/plugins/fastify.plugin.auth.ts
+++ b/src/fastify/plugins/fastify.plugin.auth.ts
@@ -1,11 +1,11 @@
-import fastify, { FastifyInstance, FastifyRequest } from "fastify";
+import { FastifyInstance, FastifyRequest } from "fastify";
 import fp from "fastify-plugin";
-import { ErrorName } from "../../common";
-import { assert } from "../../core/core.assert";
 import cookie from "@fastify/cookie";
-import { safe } from "../../core";
+import { ErrorName } from "../../common/index.js";
+import { assert } from "../../core/core.assert.js";
+import { safe } from "../../core/index.js";
 
-const enum AuthenticationMethod {
+declare enum AuthenticationMethod {
   cookieJwt = "cookieJwt",
   bearer = "bearer",
   xApiKey = "xApiKey",
@@ -81,11 +81,11 @@ async function authPluginFn<
 
 async function authPluginFn<
   Options extends
-    | NotEmpty<Record<string, unknown> & { jwtCookieName?: string }>
-    | never,
+  | NotEmpty<Record<string, unknown> & { jwtCookieName?: string }>
+  | never,
   OptionsForGetRequestByAuthMethodHelper extends
-    | NotEmpty<Record<string, unknown>>
-    | never,
+  | NotEmpty<Record<string, unknown>>
+  | never,
   RequestUser extends { id: string } = { id: string },
 >(
   fastify: FastifyInstance,


### PR DESCRIPTION
- Add explicit `.js` extensions to relative imports in ESM build to support `moduleResolution: NodeNext`.
- Change `const enum` to `declare enum` for  support of `verbatimModuleSyntax` and `isolatedModules`.